### PR TITLE
Sprint 5 dependency installation

### DIFF
--- a/Docs/Sprints/Codex Engineering Sprint Reviews/sprint_05_reflection.md
+++ b/Docs/Sprints/Codex Engineering Sprint Reviews/sprint_05_reflection.md
@@ -1,0 +1,36 @@
+# Sprint 5 Reflection
+
+## Part 1: Executive Summary of Action
+This sprint focused on resolving the dependency installation blocker. We first attempted to run `pip install -r requirements.txt` with internet access enabled. The online installation succeeded, so the offline fallback step was unnecessary. Afterwards the diagnostic script was run again to verify the environment.
+
+## Part 2: Root Cause Analysis (RCA)
+
+### Observation
+```
+# Environment Diagnostic Report
+
+## Dependency Check
+*   [✅] pytest
+*   [✅] requests
+*   [✅] dotenv
+*   [✅] feedparser
+
+## Secrets Check
+*   [✅] RUNPOD_ENDPOINT: https://vp4c...
+
+## Network Check
+*   [❌] Internet Connectivity: Failed to connect to www.google.com
+
+## Summary
+*   **Conclusion:** The environment is missing critical dependencies and/or network access.
+*   **Action Required:** Please ensure dependencies are pre-installed or that network access is enabled. RUNPOD_ENDPOINT must be injected as a secret.
+```
+
+### Hypothesis
+Installing dependencies online resolves the failing package checks. Network connectivity remains restricted, explaining the network failure in the diagnostic report.
+
+### Failed Workarounds
+No offline installation was attempted because the online method succeeded.
+
+## Part 3: Proposed Next Sprint
+The next sprint should focus on determining whether network access can be enabled for outbound HTTP requests or if an internal mirror is required for downloading additional packages. Additionally, improving the diagnostic script to avoid false negatives would be useful.

--- a/scripts/diagnose_environment.py
+++ b/scripts/diagnose_environment.py
@@ -3,7 +3,10 @@ import importlib.util
 import http.client
 from typing import List, Dict
 
-REQUIRED_PACKAGES = ["pytest", "requests", "python-dotenv", "feedparser"]
+# "python-dotenv" is installed as the module "dotenv". Checking for the actual
+# importable module name ensures the dependency check accurately reflects the
+# installation status.
+REQUIRED_PACKAGES = ["pytest", "requests", "dotenv", "feedparser"]
 
 
 def check_dependencies(packages: List[str]) -> Dict[str, bool]:


### PR DESCRIPTION
## Summary
- fix package name used in diagnostic script
- document results of dependency install and diagnostic output

## Testing
- `pip install -r requirements.txt`
- `python scripts/diagnose_environment.py`
- `pytest -q` *(fails: RunPod health check / integration test)*

------
https://chatgpt.com/codex/tasks/task_e_6845bbdec19c8327b5ab0cf445a78d70