### PR TITLE
feat: add temporary audio file for proxy test

### DIFF
--- a/tests/integration/test_transcribe_proxy.py
+++ b/tests/integration/test_transcribe_proxy.py
@@ -1,0 +1,28 @@
+import os
+import wave
+import pytest
+
+from spiceflow.clients.runpod_client import RunPodClient
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("RUNPOD_ENDPOINT"),
+    reason="RUNPOD_ENDPOINT not set",
+)
+def test_transcribe_proxy(tmp_path):
+    audio_file = tmp_path / "temp.wav"
+    with wave.open(str(audio_file), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(16000)
+        wf.writeframes(b"\x00\x00" * 16000)
+    client = RunPodClient()
+    result = client.run(
+        str(audio_file),
+        model="Systran/faster-whisper-large-v3",
+        task="transcribe",
+        temperature=0.0,
+        stream=False,
+    )
+    assert isinstance(result, str) and result.strip()


### PR DESCRIPTION
## Summary
- create `test_transcribe_proxy.py` that generates a temporary WAV file instead of relying on a fixture
- remove unused `tests/fixtures/sample.mp3`

## Testing
- `env -u RUNPOD_ENDPOINT pytest -q`
- `env -u RUNPOD_ENDPOINT -u RUNPOD_API_KEY python scripts/run_e2e_transcription.py` *(fails: Missing RUNPOD_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_6845f6287e688327802d88487d91dc18