### PR TITLE
Add CI transcript job with short clip mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,31 @@ jobs:
           RUNPOD_ENDPOINT: ${{ secrets.RUNPOD_ENDPOINT }}
           RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
         run: python scripts/run_e2e_transcription.py
+
+  produce-transcript:
+    if: github.ref == 'refs/heads/main' && github.actor != 'github-actions[bot]'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Transcribe short clip
+        env:
+          CI: 'true'
+          RUNPOD_ENDPOINT: ${{ secrets.RUNPOD_ENDPOINT }}
+        run: python scripts/chunk_and_transcribe.py
+      - name: Commit transcript
+        run: |
+          git config user.name github-actions
+          git config user.email actions@github.com
+          git add 30s_clip.json
+          git commit -m "Add CI transcript [skip ci]"
+          git push

--- a/scripts/chunk_and_transcribe.py
+++ b/scripts/chunk_and_transcribe.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 import subprocess
 import requests
@@ -7,8 +8,14 @@ from spiceflow.rss_parser import RSSParser
 from spiceflow.clients.runpod_client import RunPodClient
 
 FEED_URL = "https://feeds.acast.com/public/shows/65bac3af03341c00164bf93b"
-OUTPUT_AUDIO = Path("latest_shift_key_10m.mp3")
-TRANSCRIPT_PATH = Path("latest_shift_key_10m.json")
+
+CI_MODE = os.getenv("CI") == "true"
+CLIP_SECONDS = 30 if CI_MODE else 600
+
+OUTPUT_AUDIO = (
+    Path("latest_shift_key_30s.mp3") if CI_MODE else Path("latest_shift_key_10m.mp3")
+)
+TRANSCRIPT_PATH = Path("30s_clip.json") if CI_MODE else Path("10m_clip.json")
 
 
 def fetch_latest_episode_url() -> str:
@@ -28,7 +35,7 @@ def download_clip(url: str, path: Path) -> None:
         "-i",
         url,
         "-t",
-        "600",
+        str(CLIP_SECONDS),
         "-acodec",
         "copy",
         str(path),

--- a/tests/test_chunk_transcribe.py
+++ b/tests/test_chunk_transcribe.py
@@ -1,3 +1,4 @@
+import importlib
 import json
 import sys
 from pathlib import Path
@@ -5,10 +6,19 @@ import types
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-import scripts.chunk_and_transcribe as mod
+
+def load_module():
+    import scripts.chunk_and_transcribe as mod
+    return importlib.reload(mod)
 
 
-def test_chunk_and_transcribe(monkeypatch, tmp_path):
+def common_setup(monkeypatch, tmp_path, ci=False, patch_paths=True):
+    if ci:
+        monkeypatch.setenv("CI", "true")
+    else:
+        monkeypatch.delenv("CI", raising=False)
+    mod = load_module()
+
     xml = "<rss><channel><item><enclosure url='http://example.com/a.mp3'/></item></channel></rss>"
 
     def fake_get(url, timeout=10, stream=False):
@@ -17,17 +27,41 @@ def test_chunk_and_transcribe(monkeypatch, tmp_path):
     monkeypatch.setattr(mod.requests, "get", fake_get)
 
     audio_path = tmp_path / "clip.mp3"
+
     def fake_download(url, path):
         path.write_text("audio")
+
     monkeypatch.setattr(mod, "download_clip", fake_download)
 
     result_json = tmp_path / "out.json"
-    monkeypatch.setattr(mod, "OUTPUT_AUDIO", audio_path)
-    monkeypatch.setattr(mod, "TRANSCRIPT_PATH", result_json)
+    if patch_paths:
+        monkeypatch.setattr(mod, "OUTPUT_AUDIO", audio_path)
+        monkeypatch.setattr(mod, "TRANSCRIPT_PATH", result_json)
 
     dummy_client = types.SimpleNamespace(transcribe=lambda p: "hi")
     monkeypatch.setattr(mod, "RunPodClient", lambda: dummy_client)
 
+    return mod, result_json
+
+
+def test_chunk_and_transcribe_default(monkeypatch, tmp_path):
+    mod, result_json = common_setup(monkeypatch, tmp_path, ci=False)
+    assert mod.CLIP_SECONDS == 600
+    mod.main()
+    data = json.loads(result_json.read_text())
+    assert data["transcript"] == "hi"
+
+
+def test_chunk_and_transcribe_ci(monkeypatch, tmp_path):
+    mod, _ = common_setup(monkeypatch, tmp_path, ci=True, patch_paths=False)
+    assert mod.CLIP_SECONDS == 30
+    assert mod.TRANSCRIPT_PATH.name == "30s_clip.json"
+    # now patch paths and client for execution
+    result_json = tmp_path / "out.json"
+    monkeypatch.setattr(mod, "OUTPUT_AUDIO", tmp_path / "clip.mp3")
+    monkeypatch.setattr(mod, "TRANSCRIPT_PATH", result_json)
+    dummy_client = types.SimpleNamespace(transcribe=lambda p: "hi")
+    monkeypatch.setattr(mod, "RunPodClient", lambda: dummy_client)
     mod.main()
     data = json.loads(result_json.read_text())
     assert data["transcript"] == "hi"

--- a/tests/test_chunk_transcribe_runpod_client.py
+++ b/tests/test_chunk_transcribe_runpod_client.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from spiceflow.clients.runpod_client import RunPodClient
+
+
+class DummyClient:
+    def __init__(self, endpoint, timeout=300):
+        self.endpoint = endpoint
+        self.timeout = timeout
+        self.calls = []
+
+    def predict(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return "ok"
+
+
+def test_chunk_transcribe_runpod_client(monkeypatch):
+    dummy = DummyClient("http://api")
+    monkeypatch.setenv("RUNPOD_ENDPOINT", "http://api")
+    monkeypatch.setattr(
+        "spiceflow.clients.runpod_client.Client", lambda endpoint, timeout=300: dummy
+    )
+    client = RunPodClient()
+    result = client.transcribe("file.wav", stream=True)
+    assert result == "ok"
+    assert dummy.calls


### PR DESCRIPTION
## Summary
- make `chunk_and_transcribe.py` respect `CI=true` with 30-second clip
- create tests for CI mode and RunPod client
- add `produce-transcript` job to CI workflow

## Testing
- `pytest --cov=src --cov-fail-under=85 -k test_chunk_transcribe -q`

------
https://chatgpt.com/codex/tasks/task_e_68460e65bd288327a80316f2c997da4a